### PR TITLE
time expression is evaluated when defined, same value used for each call

### DIFF
--- a/c3/account.py
+++ b/c3/account.py
@@ -242,8 +242,11 @@ class Account(ApiClient):
         return orderResponse
 
     def cancelMarketOrders(
-        self, marketId: str, all_orders_until: int = int(time.time() * 1000)
+        self, marketId: str, all_orders_until = None
     ):
+        if all_orders_until is None:
+            all_orders_until = int(time.time() * 1000)
+        
         cancelSignatureRequest = CancelSignatureRequest(
             op=RequestOperation.Cancel,
             all_orders_until=all_orders_until,


### PR DESCRIPTION
Default parameter values are always evaluated when, and only when, the “def” statement they belong to is executed.
Example:
Close orders with 'allOrdersUntil': 1714422227467
Wait 4 seconds
Close orders with 'allOrdersUntil': 1714422227467